### PR TITLE
Adding handling for exceptions when MockAgent is not running 

### DIFF
--- a/WindowsRunnerCSharp/README.md
+++ b/WindowsRunnerCSharp/README.md
@@ -30,4 +30,6 @@ To run this sample locally:
 
 **Known Limitations**
 * Currently, this sample will only work locally if you are also running the local agent. If you see a GSDK Exception on initialization, make sure the local agent is running.
-* Note that the Debug version of the sample still has issues that are being corrected. Please build the solution as **Release|x64**.
+* If you continue to see an issue repeatedly after starting the local agent or changing the MultiplayerSettings.json file, close the program (Visual Studio, Powershell,
+* Command Prompt, etc.) you were using to run the WindowsRunnerCSharp executable or solution, start the local agent, reopen the program, and try running the 
+* WindowsRunnerCSharp executable or solution again. 

--- a/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
+++ b/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
@@ -90,7 +90,8 @@ namespace WindowsRunnerCSharp
             }
             else
             {
-                LogMessage("Cannot find ListeningPortKey in GSDK Config Settings. Please make sure the MockAgent is running.");
+                LogMessage($"Cannot find {ListeningPortKey} in GSDK Config Settings. Please make sure the MockAgent is running " +
+                           $"and that the MultiplayerSettings.json file includes {ListeningPortKey} as a GamePort Name.");
                 return;
             }
 

--- a/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
+++ b/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
@@ -33,7 +33,7 @@ namespace WindowsRunnerCSharp
 
         static void OnShutdown()
         {
-            GameserverSDK.LogMessage("Shutting down...");
+            LogMessage("Shutting down...");
             _listener.Stop();
             _listener.Close();
         }
@@ -46,18 +46,32 @@ namespace WindowsRunnerCSharp
 
         static void OnMaintenanceScheduled(DateTimeOffset time)
         {
-            GameserverSDK.LogMessage($"Maintenance Scheduled at: {time}");
+            LogMessage($"Maintenance Scheduled at: {time}");
             _nextMaintenance = time;
         }
 
         static void Main(string[] args)
         {
             // GSDK Setup
-            GameserverSDK.Start();
+            try
+            {
+                GameserverSDK.Start();
+            }
+            catch (Microsoft.Playfab.Gaming.GSDK.CSharp.GSDKInitializationException initEx)
+            {
+                LogMessage("Cannot start GSDK. Please make sure the MockAgent is running. ", false);
+                LogMessage($"Got Exception: {initEx.ToString()}", false);
+                return;
+            }
+            catch (Exception ex)
+            {
+                LogMessage($"Got Exception: {ex.ToString()}", false);
+            }
+
             GameserverSDK.RegisterShutdownCallback(OnShutdown);
             GameserverSDK.RegisterHealthCallback(IsHealthy);
             GameserverSDK.RegisterMaintenanceCallback(OnMaintenanceScheduled);
-
+            
             // Read our asset file
             if (File.Exists(AssetFilePath))
             {
@@ -65,12 +79,20 @@ namespace WindowsRunnerCSharp
             }
 
             IDictionary<string, string> initialConfig = GameserverSDK.getConfigSettings();
-
+            
             // Start the http server
-            int listeningPort = int.Parse(initialConfig[ListeningPortKey]);
-            string address = $"http://*:{listeningPort}/";
-            _listener.Prefixes.Add(address);
-            _listener.Start();
+            if (initialConfig?.ContainsKey(ListeningPortKey) == true)
+            {
+                int listeningPort = int.Parse(initialConfig[ListeningPortKey]);
+                string address = $"http://*:{listeningPort}/";
+                _listener.Prefixes.Add(address);
+                _listener.Start();
+            }
+            else
+            {
+                LogMessage("Cannot find ListeningPortKey in GSDK Config Settings. Please make sure the MockAgent is running.");
+                return;
+            }
 
             // Load our game certificate if it was installed
             if (initialConfig?.ContainsKey(GameCertAlias) == true)
@@ -86,12 +108,12 @@ namespace WindowsRunnerCSharp
                 }
                 else
                 {
-                    GameserverSDK.LogMessage("Could not find installed game cert in LocalMachine\\My. Expected thumbprint is: " + expectedThumbprint);
+                    LogMessage("Could not find installed game cert in LocalMachine\\My. Expected thumbprint is: " + expectedThumbprint);
                 }
             }
             else
             {
-                GameserverSDK.LogMessage("Config did not contain cert! Config is: " + string.Join(";", initialConfig.Select(x => x.Key + "=" + x.Value)));
+                LogMessage("Config did not contain cert! Config is: " + string.Join(";", initialConfig.Select(x => x.Key + "=" + x.Value)));
             }
 
             Thread t = new Thread(ProcessRequests);
@@ -106,13 +128,13 @@ namespace WindowsRunnerCSharp
 
                 if (activeConfig.TryGetValue(GameserverSDK.SessionCookieKey, out string sessionCookie))
                 {
-                    GameserverSDK.LogMessage($"The session cookie from the allocation call is: {sessionCookie}");
+                    LogMessage($"The session cookie from the allocation call is: {sessionCookie}");
                 }
             }
             else
             {
                 // No allocation happened, the server is getting terminated (likely because there are too many already in standing by)
-                GameserverSDK.LogMessage("Server is getting terminated.");
+                LogMessage("Server is getting terminated.");
             }
         }
 
@@ -130,8 +152,7 @@ namespace WindowsRunnerCSharp
                     HttpListenerResponse response = context.Response;
 
                     string requestMessage = string.Format("HTTP:Received {0}", request.Headers.ToString());
-                    GameserverSDK.LogMessage(requestMessage);
-                    Console.WriteLine(requestMessage);
+                    LogMessage(requestMessage);
 
                     IDictionary<string, string> config = null;
 
@@ -165,12 +186,21 @@ namespace WindowsRunnerCSharp
                 catch (HttpListenerException httpEx)
                 {
                     // This one is expected if we stopped the listener because we were asked to shutdown
-                    GameserverSDK.LogMessage($"Got HttpListenerException: {httpEx.ToString()}, we are being shut down.");
+                    LogMessage($"Got HttpListenerException: {httpEx.ToString()}, we are being shut down.");
                 }
                 catch (Exception ex)
                 {
-                    GameserverSDK.LogMessage($"Got Exception: {ex.ToString()}");
+                    LogMessage($"Got Exception: {ex.ToString()}");
                 }
+            }
+        }
+
+        private static void LogMessage(string message, bool enableGSDKLogging = true)
+        {
+            Console.WriteLine(message);
+            if (enableGSDKLogging)
+            {
+                GameserverSDK.LogMessage(message);
             }
         }
     }

--- a/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
+++ b/WindowsRunnerCSharp/WindowsRunnerCSharp/Program.cs
@@ -71,7 +71,7 @@ namespace WindowsRunnerCSharp
             GameserverSDK.RegisterShutdownCallback(OnShutdown);
             GameserverSDK.RegisterHealthCallback(IsHealthy);
             GameserverSDK.RegisterMaintenanceCallback(OnMaintenanceScheduled);
-            
+
             // Read our asset file
             if (File.Exists(AssetFilePath))
             {
@@ -79,7 +79,7 @@ namespace WindowsRunnerCSharp
             }
 
             IDictionary<string, string> initialConfig = GameserverSDK.getConfigSettings();
-            
+
             // Start the http server
             if (initialConfig?.ContainsKey(ListeningPortKey) == true)
             {

--- a/WindowsRunnerCSharp/WindowsRunnerCSharp/WindowsRunnerCSharp.csproj
+++ b/WindowsRunnerCSharp/WindowsRunnerCSharp/WindowsRunnerCSharp.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="com.playfab.csharpgsdk">
-      <Version>0.3.181110</Version>
+      <Version>0.4.181201</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>

--- a/WindowsRunnerCSharp/WindowsRunnerCSharp/WindowsRunnerCSharp.csproj
+++ b/WindowsRunnerCSharp/WindowsRunnerCSharp/WindowsRunnerCSharp.csproj
@@ -54,7 +54,7 @@
       <Version>0.4.181201</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Updated the GSDK and Newtonsoft.Json Nuget Packages. 
- Added a Try/Catch for starting the GSDK which throws an exception if the MockAgent is not running.
- Added a check for the ListeningPortKey in case it cannot be found in the initial config, which might occur if the MockAgent is not running properly.
- Enabled console and GSDK logging for all messages (unless explicitly set otherwise - ex: If the GSDK does not start, we cannot call it to log messages). 